### PR TITLE
Fix bech32 prefix for Litecoin mainnet and testnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test.js
 docker_data/
 docs/
 browser/bcoin*
+.idea

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -383,7 +383,7 @@ main.addressPrefix = {
   scripthash: 0x32,
   witnesspubkeyhash: 0x06,
   witnessscripthash: 0x0a,
-  bech32: 'lc'
+  bech32: 'ltc'
 };
 
 /**
@@ -570,7 +570,7 @@ testnet.addressPrefix = {
   scripthash: 0xc4,
   witnesspubkeyhash: 0x03,
   witnessscripthash: 0x28,
-  bech32: 'tb'
+  bech32: 'tltc'
 };
 
 testnet.requireStandard = false;


### PR DESCRIPTION
This PR changes the bech32 prefix from lc1 to ltc1 on mainnet, and from tb1 to tltc1 on testnet.